### PR TITLE
Fix the agent model by providing the correct attribute to the ChatLiteLLM

### DIFF
--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -85,7 +85,7 @@ class ToolMonitoringMiddleware(AgentMiddleware):
     ) -> ToolMessage | Command:
         args = format_tool_args_compact(request.tool_call['args'])
         self.log.info(f"{request.tool_call['name']}({args})")
-        
+
         try:
             result = await handler(request)
             self.log.info(f"{request.tool_call['name']} Done!")
@@ -126,7 +126,7 @@ class JupyternautPersona(BasePersona):
         return nb_toolkit
 
     async def get_agent(self, model_id: str, model_args, system_prompt: str):
-        model = ChatLiteLLM(**model_args, model_id=model_id, streaming=True)
+        model = ChatLiteLLM(**model_args, model=model_id, streaming=True)
         memory_store = await self.get_memory_store()
 
         if not hasattr(self, "search_tool"):
@@ -139,7 +139,7 @@ class JupyternautPersona(BasePersona):
             self.tool_call_handler = ToolMonitoringMiddleware(
                 persona=self
             )
-        
+
         return create_agent(
             model,
             system_prompt=system_prompt,
@@ -177,7 +177,7 @@ class JupyternautPersona(BasePersona):
                 node = metadata["langgraph_node"]
                 content_blocks = token.content_blocks
                 if (
-                    node == "model" 
+                    node == "model"
                     and content_blocks
                 ):
                     if token.text:


### PR DESCRIPTION
This PR fixes the model of the agent, which is not properly setup because of a typo in the `ChatLiteLLM` attribute.

### Context

> I think that the correct parameter should be `model=model_id` (*model* instead of *model_id*), according to the `ChatLiteLLM` [attribute](https://github.com/jupyter-ai-contrib/jupyter-ai-jupyternaut/blob/dc798dcf92b04f721bf080bd5fb0707d4a77bc56/jupyter_ai_jupyternaut/jupyternaut/chat_models.py#L240).
> 
> When testing this PR, the backend is complaining about missing OpenAi API key. Trying to debug it, it seems that the model setup in `ChatLiteLLM` is always the default one, `gpt-3.5-turbo`.

_Originally posted by @brichet in https://github.com/jupyter-ai-contrib/jupyter-ai-jupyternaut/pull/17#discussion_r2489932221_

cc. @3coins @dlqqq 