### PR TITLE
Fix `edit_cell()` tool

### DIFF
--- a/jupyter_ai_jupyternaut/jupyternaut/toolkits/notebook.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/toolkits/notebook.py
@@ -1072,8 +1072,7 @@ async def edit_cell(file_path: str, cell_id: str, content: str) -> None:
             cell_index = _get_cell_index_from_id_ydoc(ydoc, resolved_cell_id)
             if cell_index is not None:
                 ycell = ydoc._ycells[cell_index]
-                #await write_to_cell_collaboratively(ydoc, ycell, content)
-                ycell["source"] = content
+                await write_to_cell_collaboratively(ydoc, ycell, content)
             else:
                 raise ValueError(f"Cell with {cell_id=} not found in notebook")
         else:


### PR DESCRIPTION
## Description

- Closes #26.
- Fixes the `edit_cell()` tool by un-commenting a key line.

The `write_to_cell_collaboratively()` util function should work fine since the `add_cell()` tool also uses this function and works fine. The line may have originally been commented out by accident during development.

## Demo


https://github.com/user-attachments/assets/13438a7c-6a59-45d3-91f1-12b9b7b9f767


