### PR TITLE
Require `@jupyter/chat` as a singleton shared package

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,12 @@
                 }
             }
         },
+        "sharedPackages": {
+            "@jupyter/chat": {
+                "singleton": true,
+                "bundled": false
+            }
+        },
         "extension": true,
         "outputDir": "jupyter_ai_jupyternaut/labextension",
         "schemaDir": "schema"


### PR DESCRIPTION
jupyter-ai-jupyternaut requires registries identified in @jupyter/chat (such as @jupyter/chat.IMessageFooterRegistry)

To guarantee importing the same @jupyter/chat tokens than the plugin providing them (jupyterlab-chat-extension) when distributing both as pre-built extensions, we must properly define @jupyter/chat as a non-bundled singleton for webpack bundling, according to https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#requiring-a-service