### PR TITLE
fix: stop ChatLiteLLM._client_params from mutating litellm module globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.0.11
+
+([Full Changelog](https://github.com/jupyter-ai-contrib/jupyter-ai-jupyternaut/compare/v0.0.10...fafb1c3f1072bfe6b524e6535ca87e705f45da9b))
+
+### Bugs fixed
+
+- Fixes errors with missing usage tokens [#48](https://github.com/jupyter-ai-contrib/jupyter-ai-jupyternaut/pull/48) ([@3coins](https://github.com/3coins), [@dlqqq](https://github.com/dlqqq))
+
+### Maintenance and upkeep improvements
+
+- Updates jupyter-ai-litellm version for mitigating litellm vulnerability [#49](https://github.com/jupyter-ai-contrib/jupyter-ai-jupyternaut/pull/49) ([@3coins](https://github.com/3coins), [@dlqqq](https://github.com/dlqqq))
+
+### Contributors to this release
+
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/use/#how-does-this-tool-define-contributions-in-the-reports).
+
+([GitHub contributors page for this release](https://github.com/jupyter-ai-contrib/jupyter-ai-jupyternaut/graphs/contributors?from=2026-03-02&to=2026-03-24&type=c))
+
+@3coins ([activity](https://github.com/search?q=repo%3Ajupyter-ai-contrib%2Fjupyter-ai-jupyternaut+involves%3A3coins+updated%3A2026-03-02..2026-03-24&type=Issues)) | @dlqqq ([activity](https://github.com/search?q=repo%3Ajupyter-ai-contrib%2Fjupyter-ai-jupyternaut+involves%3Adlqqq+updated%3A2026-03-02..2026-03-24&type=Issues))
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.0.10
 
 ([Full Changelog](https://github.com/jupyter-ai-contrib/jupyter-ai-jupyternaut/compare/v0.0.9...4808b8bd1748383baec9a26de35c4a3f75e5c215))
@@ -28,8 +51,6 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 ([GitHub contributors page for this release](https://github.com/jupyter-ai-contrib/jupyter-ai-jupyternaut/graphs/contributors?from=2026-01-13&to=2026-03-02&type=c))
 
 @andrii-i ([activity](https://github.com/search?q=repo%3Ajupyter-ai-contrib%2Fjupyter-ai-jupyternaut+involves%3Aandrii-i+updated%3A2026-01-13..2026-03-02&type=Issues)) | @brichet ([activity](https://github.com/search?q=repo%3Ajupyter-ai-contrib%2Fjupyter-ai-jupyternaut+involves%3Abrichet+updated%3A2026-01-13..2026-03-02&type=Issues)) | @dlqqq ([activity](https://github.com/search?q=repo%3Ajupyter-ai-contrib%2Fjupyter-ai-jupyternaut+involves%3Adlqqq+updated%3A2026-01-13..2026-03-02&type=Issues)) | @erkin98 ([activity](https://github.com/search?q=repo%3Ajupyter-ai-contrib%2Fjupyter-ai-jupyternaut+involves%3Aerkin98+updated%3A2026-01-13..2026-03-02&type=Issues)) | @magnuslarsen ([activity](https://github.com/search?q=repo%3Ajupyter-ai-contrib%2Fjupyter-ai-jupyternaut+involves%3Amagnuslarsen+updated%3A2026-01-13..2026-03-02&type=Issues)) | @subsriram ([activity](https://github.com/search?q=repo%3Ajupyter-ai-contrib%2Fjupyter-ai-jupyternaut+involves%3Asubsriram+updated%3A2026-01-13..2026-03-02&type=Issues))
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.0.9
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ To install the extension, execute:
 pip install jupyter_ai_jupyternaut
 ```
 
+## Optional features
+
+The core package provides Jupyternaut's chat and notebook tools, keeping
+conversation memory in memory. Persistent conversation memory is available as an
+optional extra:
+
+| Extra         | Enables                                                                                                                     | Without it                                                              |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `persistence` | Conversation memory persisted to a local SQLite database so it survives server restarts (via `langgraph-checkpoint-sqlite`) | Conversation memory is kept only for the lifetime of the server process |
+| `all`         | All optional runtime features. Currently this is the same as `persistence`                                                  | —                                                                       |
+
+For example:
+
+```bash
+# persistent conversation memory
+pip install "jupyter_ai_jupyternaut[persistence]"
+# every optional feature
+pip install "jupyter_ai_jupyternaut[all]"
+```
+
 ## Uninstall
 
 To remove the extension, execute:

--- a/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
@@ -638,14 +638,14 @@ def _create_usage_metadata(usage: Usage) -> UsageMetadata:
     metadata object (`langchain_core.messages.ai.UsageMetadata`).
     """
     input_tokens = usage.prompt_tokens or 0
-    input_audio_tokens = getattr(usage.prompt_tokens_details, 'audio_tokens', 0)
+    input_audio_tokens = getattr(usage.prompt_tokens_details, 'audio_tokens', 0) or 0
     output_tokens = usage.completion_tokens or 0
-    output_audio_tokens = getattr(usage.completion_tokens_details, 'audio_tokens', 0)
-    output_reasoning_tokens = getattr(usage.completion_tokens_details, 'reasoning_tokens', 0)
+    output_audio_tokens = getattr(usage.completion_tokens_details, 'audio_tokens', 0) or 0
+    output_reasoning_tokens = getattr(usage.completion_tokens_details, 'reasoning_tokens', 0) or 0
     total_tokens = input_tokens + output_tokens
 
-    cache_creation_tokens = getattr(usage.prompt_tokens_details, 'cache_creation_tokens', 0)
-    cache_read_tokens = getattr(usage.prompt_tokens_details,'cached_tokens', 0)
+    cache_creation_tokens = getattr(usage.prompt_tokens_details, 'cache_creation_tokens', 0) or 0
+    cache_read_tokens = getattr(usage.prompt_tokens_details,'cached_tokens', 0) or 0
 
     return UsageMetadata(
         input_tokens=input_tokens,

--- a/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
@@ -299,27 +299,18 @@ class ChatLiteLLM(BaseChatModel):
         set_model_value = self.model
         if self.model_name is not None:
             set_model_value = self.model_name
-        self.client.api_base = self.api_base
-        self.client.api_key = self.api_key
-        for named_api_key in [
-            "openai_api_key",
-            "azure_api_key",
-            "anthropic_api_key",
-            "replicate_api_key",
-            "cohere_api_key",
-            "openrouter_api_key",
-        ]:
-            if api_key_value := getattr(self, named_api_key):
-                setattr(
-                    self.client,
-                    named_api_key.replace("_api_key", "_key"),
-                    api_key_value,
-                )
-        self.client.organization = self.organization
+        # Pass credentials per-request instead of mutating litellm module
+        # globals. Setting attributes on self.client (which IS the litellm
+        # module) pollutes every subsequent litellm call in the process,
+        # regardless of provider. This breaks providers that rely on
+        # DefaultAzureCredential (e.g. azure_ai/agents/*) because
+        # litellm.openai_key gets picked up as the API key instead.
         creds: Dict[str, Any] = {
             "model": set_model_value,
             "force_timeout": self.request_timeout,
             "api_base": self.api_base,
+            "api_key": self.api_key,
+            "organization": self.organization,
         }
         return {**self._default_params, **creds}
 

--- a/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
@@ -273,6 +273,8 @@ class ChatLiteLLM(BaseChatModel):
     """Number of chat completions to generate for each prompt. Note that the API may
        not return the full n completions if duplicates are generated."""
     max_tokens: Optional[int] = None
+    num_ctx: Optional[int] = None
+    """Size of the context window"""
 
     max_retries: int = 1
 
@@ -321,7 +323,10 @@ class ChatLiteLLM(BaseChatModel):
             "force_timeout": self.request_timeout,
             "api_base": self.api_base,
         }
-        return {**self._default_params, **creds}
+        params = {**self._default_params, **creds}
+        if self.num_ctx is not None:
+            params['num_ctx'] = self.num_ctx
+        return params
 
     def completion_with_retry(
         self, run_manager: Optional[CallbackManagerForLLMRun] = None, **kwargs: Any
@@ -416,6 +421,9 @@ class ChatLiteLLM(BaseChatModel):
 
         if values["top_k"] is not None and values["top_k"] <= 0:
             raise ValueError("top_k must be positive")
+
+        if values["num_ctx"] is not None and values["num_ctx"] <= 0:
+            raise ValueError("num_ctx must be positive")
 
         return values
 
@@ -624,7 +632,7 @@ class ChatLiteLLM(BaseChatModel):
             "temperature": self.temperature,
             "top_p": self.top_p,
             "top_k": self.top_k,
-            "n": self.n,
+            "n": self.n
         }
 
     @property

--- a/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
@@ -301,27 +301,18 @@ class ChatLiteLLM(BaseChatModel):
         set_model_value = self.model
         if self.model_name is not None:
             set_model_value = self.model_name
-        self.client.api_base = self.api_base
-        self.client.api_key = self.api_key
-        for named_api_key in [
-            "openai_api_key",
-            "azure_api_key",
-            "anthropic_api_key",
-            "replicate_api_key",
-            "cohere_api_key",
-            "openrouter_api_key",
-        ]:
-            if api_key_value := getattr(self, named_api_key):
-                setattr(
-                    self.client,
-                    named_api_key.replace("_api_key", "_key"),
-                    api_key_value,
-                )
-        self.client.organization = self.organization
+        # Pass credentials per-request instead of mutating litellm module
+        # globals. Setting attributes on self.client (which IS the litellm
+        # module) pollutes every subsequent litellm call in the process,
+        # regardless of provider. This breaks providers that rely on
+        # DefaultAzureCredential (e.g. azure_ai/agents/*) because
+        # litellm.openai_key gets picked up as the API key instead.
         creds: Dict[str, Any] = {
             "model": set_model_value,
             "force_timeout": self.request_timeout,
             "api_base": self.api_base,
+            "api_key": self.api_key,
+            "organization": self.organization,
         }
         params = {**self._default_params, **creds}
         if self.num_ctx is not None:

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -2,12 +2,23 @@ import os
 from typing import Any
 
 import aiosqlite
-from jupyter_ai_persona_manager import BasePersona, PersonaDefaults
+from jupyter_ai_persona_manager import (
+  BasePersona,
+  McpServerHttp,
+  McpServerStdio,
+  PersonaDefaults,
+)
 from jupyter_core.paths import jupyter_data_dir
 from jupyterlab_chat.models import Message
 from langchain.agents import create_agent
 from langchain.agents.middleware import wrap_tool_call
 from langchain.messages import ToolMessage
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.sessions import (
+  Connection,
+  StreamableHttpConnection,
+  StdioConnection,
+)
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 from .chat_models import ChatLiteLLM
@@ -54,10 +65,33 @@ class JupyternautPersona(BasePersona):
             self._memory_store = AsyncSqliteSaver(conn)
         return self._memory_store
 
-    def get_tools(self):
+    async def get_tools(self):
         tools = nb_toolkit
         tools += jlab_toolkit
         tools += exec_toolkit
+
+        # Add MCP tools
+        mcp_settings = self.get_mcp_settings()
+        connections: dict[str, Connection] = {}
+        for mcp in mcp_settings.mcp_servers:
+            if isinstance(mcp, McpServerHttp):
+                connection: StreamableHttpConnection = {
+                    "transport": mcp.type,
+                    "url": mcp.url,
+                    "headers": mcp.headers
+                }
+                connections[mcp.name] = connection
+            elif isinstance(mcp, McpServerStdio):
+                connection: StdioConnection = {
+                    "transport": "stdio",
+                    "command": mcp.command,
+                    "args": mcp.args,
+                    "env": {var.name: var.value for var in mcp.env}
+                }
+                connections[mcp.name] = connection
+        client = MultiServerMCPClient(connections)
+        tools += await client.get_tools()
+
         return tools
 
     def _create_tool_error_handler(self):
@@ -90,7 +124,7 @@ class JupyternautPersona(BasePersona):
             model,
             system_prompt=system_prompt,
             checkpointer=memory_store,
-            tools=self.get_tools(),
+            tools=await self.get_tools(),
             middleware=[self._create_tool_error_handler()],
         )
 

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -156,16 +156,25 @@ class JupyternautPersona(BasePersona):
             }
 
             async def create_aiter():
-                async for token, metadata in agent.astream(
+                stream = await agent.astream_events(
                     {"messages": [{"role": "user", "content": message.body}]},
                     {"configurable": context},
-                    stream_mode="messages",
-                ):
-                    node = metadata["langgraph_node"]
-                    content_blocks = token.content_blocks
-                    if node == "model" and content_blocks:
-                        if token.text:
-                            yield token.text
+                    version="v3"
+                )
+                async for event in stream:
+                    if event["method"] != "messages":
+                        continue
+                    data = event["params"]["data"][0]
+                    if not isinstance(data, dict):
+                        continue
+                    if data.get("event") != "content-block-delta":
+                        continue
+
+                    block = data.get("delta") or {}
+                    if block.get("type") == "text-delta":
+                        yield block.get("text", "")
+                    elif block.get("type") == "reasoning-delta":
+                        yield block.get('reasoning', '')
 
             response_aiter = create_aiter()
             await self.stream_message(response_aiter)

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -1,7 +1,6 @@
 import os
 from typing import Any
 
-import aiosqlite
 from jupyter_ai_persona_manager import (
   BasePersona,
   McpServerHttp,
@@ -19,7 +18,6 @@ from langchain_mcp_adapters.sessions import (
   StreamableHttpConnection,
   StdioConnection,
 )
-from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 from .chat_models import ChatLiteLLM
 from .prompt_template import (
@@ -59,15 +57,39 @@ class JupyternautPersona(BasePersona):
             system_prompt="...",
         )
 
-    @property
-    def yroom_manager(self):
-        return self.parent.serverapp.web_app.settings["yroom_manager"]
-
     async def get_memory_store(self):
+        """
+        Returns the checkpointer used to persist Jupyternaut's conversation
+        memory.
+
+        If the optional ``langgraph-checkpoint-sqlite`` package is installed
+        (e.g. via ``jupyter-ai-jupyternaut[persistence]``), conversation memory
+        is persisted to a local SQLite database so that it survives server
+        restarts. Otherwise, Jupyternaut falls back to an in-memory checkpointer
+        that retains memory only for the lifetime of the server process.
+        """
         if not hasattr(self, "_memory_store"):
-            conn = await aiosqlite.connect(MEMORY_STORE_PATH, check_same_thread=False)
-            self._memory_store = AsyncSqliteSaver(conn)
+            self._memory_store = await self._create_memory_store()
         return self._memory_store
+
+    async def _create_memory_store(self):
+        try:
+            import aiosqlite
+            from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+        except ImportError:
+            from langgraph.checkpoint.memory import InMemorySaver
+
+            self.log.info(
+                "`langgraph-checkpoint-sqlite` is not installed; Jupyternaut "
+                "will use in-memory conversation memory that is not persisted "
+                "across server restarts. Install "
+                "`jupyter-ai-jupyternaut[persistence]` to enable persistent "
+                "memory."
+            )
+            return InMemorySaver()
+
+        conn = await aiosqlite.connect(MEMORY_STORE_PATH, check_same_thread=False)
+        return AsyncSqliteSaver(conn)
 
     async def get_tools(self):
         tools = nb_toolkit
@@ -208,6 +230,10 @@ class JupyternautPersona(BasePersona):
         return JUPYTERNAUT_SYSTEM_PROMPT_TEMPLATE.render(**system_msg_args)
 
     async def shutdown(self):
-        if hasattr(self, "_memory_store"):
-            self.parent.event_loop.create_task(self._memory_store.conn.close())
+        # Only the SQLite-backed checkpointer holds an open connection that needs
+        # to be closed; the in-memory fallback does not.
+        memory_store = getattr(self, "_memory_store", None)
+        conn = getattr(memory_store, "conn", None)
+        if conn is not None:
+            self.parent.event_loop.create_task(conn.close())
         await super().shutdown()

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -191,7 +191,7 @@ class JupyternautPersona(BasePersona):
 
         return JUPYTERNAUT_SYSTEM_PROMPT_TEMPLATE.render(**system_msg_args)
 
-    def shutdown(self):
+    async def shutdown(self):
         if hasattr(self, "_memory_store"):
             self.parent.event_loop.create_task(self._memory_store.conn.close())
-        super().shutdown()
+        await super().shutdown()

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -30,6 +30,10 @@ from .toolkits.notebook import toolkit as nb_toolkit
 from .toolkits.jupyterlab import toolkit as jlab_toolkit
 from .toolkits.code_execution import toolkit as exec_toolkit
 
+# if the context window is too small it won't see all of the
+# system prompt
+DEFAULT_OLLAMA_NUM_CTX = 16384
+
 MEMORY_STORE_PATH = os.path.join(jupyter_data_dir(), "jupyter_ai", "memory.sqlite")
 
 JUPYTERNAUT_AVATAR_PATH = str(
@@ -117,6 +121,9 @@ class JupyternautPersona(BasePersona):
         return handle_tool_errors
 
     async def get_agent(self, model_id: str, model_args, system_prompt: str):
+        if (model_id.startswith("ollama/") or model_id.startswith("ollama_chat/")) \
+            and "num_ctx" not in model_args:
+                model_args['num_ctx'] = DEFAULT_OLLAMA_NUM_CTX
         model = ChatLiteLLM(**model_args, model=model_id, streaming=True)
         memory_store = await self.get_memory_store()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@jupyter-ai/jupyternaut",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "description": "Package providing the default AI persona, Jupyternaut, in Jupyter AI.",
     "keywords": [
         "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     # NOTE: Make sure to update the corresponding dependency in
     # `packages/jupyter-ai/package.json` to match the version range below
     "jupyterlab-chat>=0.19.0",
-    "jupyter_ai_litellm>=0.0.1",
+    "jupyter_ai_litellm>=0.0.2",
     "jinja2>=3.0,<4",
     "python_dotenv>=1,<2",
     "jupyter_ai_persona_manager>=0.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "jupyter_ai_persona_manager>=0.0.1",
     "langchain>=1.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0",
+    "langchain_mcp_adapters>=0.2,<0.3",
     "aiosqlite>=0.20",
     "jupyter_server_documents>=0.1.0a8",
     "jupyterlab-commands-toolkit>=0.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,11 @@ dependencies = [
     "python_dotenv>=1,<2",
     "jupyter_ai_persona_manager>=0.0.1",
     "langchain>=1.0.0",
-    "langgraph-checkpoint-sqlite>=3.0.0",
+    # Provides the base checkpointer (`InMemorySaver`) used for in-memory
+    # conversation memory. Persistent, SQLite-backed memory is available via the
+    # optional `persistence` extra.
+    "langgraph-checkpoint>=2.1.0",
     "langchain_mcp_adapters>=0.2,<0.3",
-    "aiosqlite>=0.20",
     "jupyter_server_documents>=0.1.0a8",
     "jupyterlab-commands-toolkit>=0.1.2",
     "jupyterlab-notebook-awareness>=0.2.0",
@@ -53,6 +55,17 @@ dependencies = [
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
+# Persist conversation memory to a local SQLite database so that it survives
+# server restarts. Without it, Jupyternaut keeps conversation memory only for
+# the lifetime of the server process (in-memory).
+persistence = [
+    "langgraph-checkpoint-sqlite>=3.0.0",
+    "aiosqlite>=0.20",
+]
+# All optional runtime features.
+all = [
+    "jupyter_ai_jupyternaut[persistence]",
+]
 test = [
     "coverage",
     "pytest",


### PR DESCRIPTION
## Summary

- Remove module-level global mutations from `ChatLiteLLM._client_params`
- Pass `api_key`, `api_base`, and `organization` as per-request parameters instead

## Problem

`ChatLiteLLM._client_params` mutates up to **9 attributes** on the `litellm` module (`self.client = litellm`) on **every request**:

```python
self.client.api_base = self.api_base        # litellm.api_base
self.client.api_key = self.api_key          # litellm.api_key
self.client.organization = self.organization # litellm.organization
# Plus: litellm.openai_key, litellm.azure_key, litellm.anthropic_key,
#        litellm.replicate_key, litellm.cohere_key, litellm.openrouter_key
```

Since `self.client` IS the `litellm` module object (set in `validate_environment`), these mutations affect **all** subsequent `litellm` calls in the process, regardless of which provider they target.

### Impact

When `OPENAI_API_KEY` is in the environment:

1. `validate_environment` sets `self.openai_api_key = "sk-..."`
2. `_client_params` executes `litellm.openai_key = "sk-..."`
3. LiteLLM's Azure AI Agents handler picks up `litellm.openai_key` via its `get_api_key()` fallback
4. The handler sends `Authorization: Bearer sk-proj-...` to Azure
5. Azure returns **401 Unauthorized** (OpenAI keys are not Azure AD tokens)

This breaks Azure AI Foundry Agents for anyone who also has `OPENAI_API_KEY` configured.

## Fix

Pass credentials per-request in the returned params dict. `litellm.completion()` / `litellm.acompletion()` accept `api_key`, `api_base`, and `organization` as keyword arguments, so no global state mutation is needed.

The provider-specific key loop is removed — `litellm` resolves the correct key from the per-request `api_key` parameter based on the model prefix.

## Test plan

- [ ] Verify OpenAI models still work when `OPENAI_API_KEY` is set
- [ ] Verify Azure AI Agents work with `DefaultAzureCredential` when `OPENAI_API_KEY` is also set
- [ ] Verify `api_base` is passed correctly per-request
- [ ] Verify no regressions in streaming (`_astream`) and non-streaming (`_generate`) paths