### PR TITLE
Add support for MCP servers

### DIFF
--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -2,13 +2,23 @@ import os
 from typing import Any
 
 import aiosqlite
-from jupyter_ai_persona_manager import BasePersona, PersonaDefaults, McpServerHttp
+from jupyter_ai_persona_manager import (
+  BasePersona,
+  McpServerHttp,
+  McpServerStdio,
+  PersonaDefaults,
+)
 from jupyter_core.paths import jupyter_data_dir
 from jupyterlab_chat.models import Message
 from langchain.agents import create_agent
 from langchain.agents.middleware import wrap_tool_call
 from langchain.messages import ToolMessage
 from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.sessions import (
+  Connection,
+  StreamableHttpConnection,
+  StdioConnection,
+)
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 from .chat_models import ChatLiteLLM
@@ -62,14 +72,24 @@ class JupyternautPersona(BasePersona):
 
         # Add MCP tools
         mcp_settings = self.get_mcp_settings()
-        mcp_tools = {}
+        connections: dict[str, Connection] = {}
         for mcp in mcp_settings.mcp_servers:
             if isinstance(mcp, McpServerHttp):
-                mcp_tools[mcp.name] = {
+                connection: StreamableHttpConnection = {
                     "transport": mcp.type,
-                    "url": mcp.url
+                    "url": mcp.url,
+                    "headers": mcp.headers
                 }
-        client = MultiServerMCPClient(mcp_tools)
+                connections[mcp.name] = connection
+            elif isinstance(mcp, McpServerStdio):
+                connection: StdioConnection = {
+                    "transport": "stdio",
+                    "command": mcp.command,
+                    "args": mcp.args,
+                    "env": {var.name: var.value for var in mcp.env}
+                }
+                connections[mcp.name] = connection
+        client = MultiServerMCPClient(connections)
         tools += await client.get_tools()
 
         return tools

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -2,12 +2,13 @@ import os
 from typing import Any
 
 import aiosqlite
-from jupyter_ai_persona_manager import BasePersona, PersonaDefaults
+from jupyter_ai_persona_manager import BasePersona, PersonaDefaults, McpServerHttp
 from jupyter_core.paths import jupyter_data_dir
 from jupyterlab_chat.models import Message
 from langchain.agents import create_agent
 from langchain.agents.middleware import wrap_tool_call
 from langchain.messages import ToolMessage
+from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 from .chat_models import ChatLiteLLM
@@ -54,10 +55,23 @@ class JupyternautPersona(BasePersona):
             self._memory_store = AsyncSqliteSaver(conn)
         return self._memory_store
 
-    def get_tools(self):
+    async def get_tools(self):
         tools = nb_toolkit
         tools += jlab_toolkit
         tools += exec_toolkit
+
+        # Add MCP tools
+        mcp_settings = self.get_mcp_settings()
+        mcp_tools = {}
+        for mcp in mcp_settings.mcp_servers:
+            if isinstance(mcp, McpServerHttp):
+                mcp_tools[mcp.name] = {
+                    "transport": mcp.type,
+                    "url": mcp.url
+                }
+        client = MultiServerMCPClient(mcp_tools)
+        tools += await client.get_tools()
+
         return tools
 
     def _create_tool_error_handler(self):
@@ -90,7 +104,7 @@ class JupyternautPersona(BasePersona):
             model,
             system_prompt=system_prompt,
             checkpointer=memory_store,
-            tools=self.get_tools(),
+            tools=await self.get_tools(),
             middleware=[self._create_tool_error_handler()],
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "jupyter_ai_persona_manager>=0.0.1",
     "langchain>=1.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0",
+    "langchain_mcp_adapters",
     "aiosqlite>=0.20",
     "jupyter_server_documents>=0.1.0a8",
     "jupyterlab-commands-toolkit>=0.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "jupyter_ai_persona_manager>=0.0.1",
     "langchain>=1.0.0",
     "langgraph-checkpoint-sqlite>=3.0.0",
-    "langchain_mcp_adapters",
+    "langchain_mcp_adapters>=0.2,<0.3",
     "aiosqlite>=0.20",
     "jupyter_server_documents>=0.1.0a8",
     "jupyterlab-commands-toolkit>=0.1.2",


### PR DESCRIPTION
This PR adds support for MCP servers, using [langchain_mcp_adapters](https://docs.langchain.com/oss/python/langchain/mcp).

The selected commands in the screenshot below provides from MCP (`jupyter_server_mcp` and `deepwiki`)

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/8ba649c8-135d-405c-af4f-296e5c497e49" />

Probably fixes https://github.com/jupyterlab/jupyter-ai/issues/1352