### PR TITLE
Make some dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ The core package provides Jupyternaut's chat and notebook tools, keeping
 conversation memory in memory. Persistent conversation memory is available as an
 optional extra:
 
-| Extra         | Enables                                                                                                             | Without it                                                              |
-| ------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Extra         | Enables                                                                                                                     | Without it                                                              |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `persistence` | Conversation memory persisted to a local SQLite database so it survives server restarts (via `langgraph-checkpoint-sqlite`) | Conversation memory is kept only for the lifetime of the server process |
-| `all`         | All optional runtime features. Currently this is the same as `persistence`                                          | —                                                                       |
+| `all`         | All optional runtime features. Currently this is the same as `persistence`                                                  | —                                                                       |
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ The core package provides Jupyternaut's chat and its tools, keeping conversation
 memory in memory. A few features are available as optional extras, so you can
 install only what you need:
 
-| Extra | Enables | Without it |
-| --- | --- | --- |
-| `rtc` | Live notebook tools — reading/editing notebooks and collaborative awareness — backed by [`jupyter-server-documents`](https://github.com/jupyter-ai-contrib/jupyter-server-documents) | Chat and the other tools still work; the notebook tools report that this extra is required |
-| `persistence` | Conversation memory persisted to a local SQLite database so it survives server restarts (via `langgraph-checkpoint-sqlite`) | Conversation memory is kept only for the lifetime of the server process |
-| `all` | Both of the extras above | — |
+| Extra         | Enables                                                                                                                                                                              | Without it                                                                                 |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `rtc`         | Live notebook tools — reading/editing notebooks and collaborative awareness — backed by [`jupyter-server-documents`](https://github.com/jupyter-ai-contrib/jupyter-server-documents) | Chat and the other tools still work; the notebook tools report that this extra is required |
+| `persistence` | Conversation memory persisted to a local SQLite database so it survives server restarts (via `langgraph-checkpoint-sqlite`)                                                          | Conversation memory is kept only for the lifetime of the server process                    |
+| `all`         | Both of the extras above                                                                                                                                                             | —                                                                                          |
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -35,21 +35,18 @@ pip install jupyter_ai_jupyternaut
 
 ## Optional features
 
-The core package provides Jupyternaut's chat and its tools, keeping conversation
-memory in memory. A few features are available as optional extras, so you can
-install only what you need:
+The core package provides Jupyternaut's chat and notebook tools, keeping
+conversation memory in memory. Persistent conversation memory is available as an
+optional extra:
 
-| Extra         | Enables                                                                                                                                                                              | Without it                                                                                 |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| `rtc`         | Live notebook tools — reading/editing notebooks and collaborative awareness — backed by [`jupyter-server-documents`](https://github.com/jupyter-ai-contrib/jupyter-server-documents) | Chat and the other tools still work; the notebook tools report that this extra is required |
-| `persistence` | Conversation memory persisted to a local SQLite database so it survives server restarts (via `langgraph-checkpoint-sqlite`)                                                          | Conversation memory is kept only for the lifetime of the server process                    |
-| `all`         | Both of the extras above                                                                                                                                                             | —                                                                                          |
+| Extra         | Enables                                                                                                             | Without it                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `persistence` | Conversation memory persisted to a local SQLite database so it survives server restarts (via `langgraph-checkpoint-sqlite`) | Conversation memory is kept only for the lifetime of the server process |
+| `all`         | All optional runtime features. Currently this is the same as `persistence`                                          | —                                                                       |
 
 For example:
 
 ```bash
-# the live notebook tools
-pip install "jupyter_ai_jupyternaut[rtc]"
 # persistent conversation memory
 pip install "jupyter_ai_jupyternaut[persistence]"
 # every optional feature

--- a/README.md
+++ b/README.md
@@ -33,6 +33,29 @@ To install the extension, execute:
 pip install jupyter_ai_jupyternaut
 ```
 
+## Optional features
+
+The core package provides Jupyternaut's chat and its tools, keeping conversation
+memory in memory. A few features are available as optional extras, so you can
+install only what you need:
+
+| Extra | Enables | Without it |
+| --- | --- | --- |
+| `rtc` | Live notebook tools — reading/editing notebooks and collaborative awareness — backed by [`jupyter-server-documents`](https://github.com/jupyter-ai-contrib/jupyter-server-documents) | Chat and the other tools still work; the notebook tools report that this extra is required |
+| `persistence` | Conversation memory persisted to a local SQLite database so it survives server restarts (via `langgraph-checkpoint-sqlite`) | Conversation memory is kept only for the lifetime of the server process |
+| `all` | Both of the extras above | — |
+
+For example:
+
+```bash
+# the live notebook tools
+pip install "jupyter_ai_jupyternaut[rtc]"
+# persistent conversation memory
+pip install "jupyter_ai_jupyternaut[persistence]"
+# every optional feature
+pip install "jupyter_ai_jupyternaut[all]"
+```
+
 ## Uninstall
 
 To remove the extension, execute:

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -57,6 +57,10 @@ class JupyternautPersona(BasePersona):
             system_prompt="...",
         )
 
+    @property
+    def yroom_manager(self):
+        return self.parent.serverapp.web_app.settings["yroom_manager"]
+
     async def get_memory_store(self):
         """
         Returns the checkpointer used to persist Jupyternaut's conversation

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -1,7 +1,6 @@
 import os
 from typing import Any
 
-import aiosqlite
 from jupyter_ai_persona_manager import (
   BasePersona,
   McpServerHttp,
@@ -19,7 +18,6 @@ from langchain_mcp_adapters.sessions import (
   StreamableHttpConnection,
   StdioConnection,
 )
-from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 from .chat_models import ChatLiteLLM
 from .prompt_template import (
@@ -59,15 +57,39 @@ class JupyternautPersona(BasePersona):
             system_prompt="...",
         )
 
-    @property
-    def yroom_manager(self):
-        return self.parent.serverapp.web_app.settings["yroom_manager"]
-
     async def get_memory_store(self):
+        """
+        Returns the checkpointer used to persist Jupyternaut's conversation
+        memory.
+
+        If the optional ``langgraph-checkpoint-sqlite`` package is installed
+        (e.g. via ``jupyter-ai-jupyternaut[persistence]``), conversation memory
+        is persisted to a local SQLite database so that it survives server
+        restarts. Otherwise, Jupyternaut falls back to an in-memory checkpointer
+        that retains memory only for the lifetime of the server process.
+        """
         if not hasattr(self, "_memory_store"):
-            conn = await aiosqlite.connect(MEMORY_STORE_PATH, check_same_thread=False)
-            self._memory_store = AsyncSqliteSaver(conn)
+            self._memory_store = await self._create_memory_store()
         return self._memory_store
+
+    async def _create_memory_store(self):
+        try:
+            import aiosqlite
+            from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+        except ImportError:
+            from langgraph.checkpoint.memory import InMemorySaver
+
+            self.log.info(
+                "`langgraph-checkpoint-sqlite` is not installed; Jupyternaut "
+                "will use in-memory conversation memory that is not persisted "
+                "across server restarts. Install "
+                "`jupyter-ai-jupyternaut[persistence]` to enable persistent "
+                "memory."
+            )
+            return InMemorySaver()
+
+        conn = await aiosqlite.connect(MEMORY_STORE_PATH, check_same_thread=False)
+        return AsyncSqliteSaver(conn)
 
     async def get_tools(self):
         tools = nb_toolkit
@@ -208,6 +230,10 @@ class JupyternautPersona(BasePersona):
         return JUPYTERNAUT_SYSTEM_PROMPT_TEMPLATE.render(**system_msg_args)
 
     async def shutdown(self):
-        if hasattr(self, "_memory_store"):
-            self.parent.event_loop.create_task(self._memory_store.conn.close())
+        # Only the SQLite-backed checkpointer holds an open connection that needs
+        # to be closed; the in-memory fallback does not.
+        memory_store = getattr(self, "_memory_store", None)
+        conn = getattr(memory_store, "conn", None)
+        if conn is not None:
+            self.parent.event_loop.create_task(conn.close())
         await super().shutdown()

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -57,10 +57,6 @@ class JupyternautPersona(BasePersona):
             system_prompt="...",
         )
 
-    @property
-    def yroom_manager(self):
-        return self.parent.serverapp.web_app.settings["yroom_manager"]
-
     async def get_memory_store(self):
         """
         Returns the checkpointer used to persist Jupyternaut's conversation

--- a/jupyter_ai_jupyternaut/jupyternaut/toolkits/utils.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/toolkits/utils.py
@@ -17,27 +17,6 @@ def get_serverapp():
     return server
 
 
-_RTC_REQUIRED_MESSAGE = (
-    "Jupyternaut's live notebook tools require the "
-    "`jupyter-server-documents` server extension, which provides the real-time "
-    "collaboration backend. Make sure `jupyter-server-documents` is installed "
-    "and enabled, then restart the Jupyter server."
-)
-
-
-def _require_web_app_setting(serverapp, key: str):
-    """Returns ``serverapp.web_app.settings[key]``.
-
-    Raises a ``RuntimeError`` with an actionable message if the setting is
-    missing, which happens when the real-time collaboration backend
-    (`jupyter-server-documents`) is not installed or enabled.
-    """
-    try:
-        return serverapp.web_app.settings[key]
-    except KeyError as e:
-        raise RuntimeError(_RTC_REQUIRED_MESSAGE) from e
-
-
 def normalize_filepath(file_path: str) -> str:
     """
     Normalizes a file path for Jupyter applications to return an absolute path.
@@ -97,7 +76,7 @@ async def get_jupyter_ydoc(file_id: str):
         `YNotebook` ydoc for the notebook
     """
     serverapp = get_serverapp()
-    yroom_manager = _require_web_app_setting(serverapp, "yroom_manager")
+    yroom_manager = serverapp.web_app.settings["yroom_manager"]
     room_id = f"json:notebook:{file_id}"
 
     if yroom_manager.has_room(room_id):
@@ -108,7 +87,7 @@ async def get_jupyter_ydoc(file_id: str):
 
 async def get_global_awareness() -> Optional[Awareness]:
     serverapp = get_serverapp()
-    yroom_manager = _require_web_app_setting(serverapp, "yroom_manager")
+    yroom_manager = serverapp.web_app.settings["yroom_manager"]
 
     room_id = "JupyterLab:globalAwareness"
     if yroom_manager.has_room(room_id):
@@ -132,7 +111,7 @@ async def get_file_id(file_path: str) -> str:
     normalized_file_path = normalize_filepath(file_path)
 
     serverapp = get_serverapp()
-    file_id_manager = _require_web_app_setting(serverapp, "file_id_manager")
+    file_id_manager = serverapp.web_app.settings["file_id_manager"]
     file_id = file_id_manager.get_id(normalized_file_path)
 
     return file_id

--- a/jupyter_ai_jupyternaut/jupyternaut/toolkits/utils.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/toolkits/utils.py
@@ -18,11 +18,10 @@ def get_serverapp():
 
 
 _RTC_REQUIRED_MESSAGE = (
-    "Jupyternaut's live notebook tools require the optional "
+    "Jupyternaut's live notebook tools require the "
     "`jupyter-server-documents` server extension, which provides the real-time "
-    "collaboration backend. Install it with "
-    "`pip install 'jupyter-ai-jupyternaut[rtc]'` (or "
-    "`conda install jupyter-server-documents`) and restart the Jupyter server."
+    "collaboration backend. Make sure `jupyter-server-documents` is installed "
+    "and enabled, then restart the Jupyter server."
 )
 
 
@@ -30,8 +29,8 @@ def _require_web_app_setting(serverapp, key: str):
     """Returns ``serverapp.web_app.settings[key]``.
 
     Raises a ``RuntimeError`` with an actionable message if the setting is
-    missing, which happens when the optional real-time collaboration backend
-    (`jupyter-server-documents`) is not installed.
+    missing, which happens when the real-time collaboration backend
+    (`jupyter-server-documents`) is not installed or enabled.
     """
     try:
         return serverapp.web_app.settings[key]

--- a/jupyter_ai_jupyternaut/jupyternaut/toolkits/utils.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/toolkits/utils.py
@@ -17,6 +17,28 @@ def get_serverapp():
     return server
 
 
+_RTC_REQUIRED_MESSAGE = (
+    "Jupyternaut's live notebook tools require the optional "
+    "`jupyter-server-documents` server extension, which provides the real-time "
+    "collaboration backend. Install it with "
+    "`pip install 'jupyter-ai-jupyternaut[rtc]'` (or "
+    "`conda install jupyter-server-documents`) and restart the Jupyter server."
+)
+
+
+def _require_web_app_setting(serverapp, key: str):
+    """Returns ``serverapp.web_app.settings[key]``.
+
+    Raises a ``RuntimeError`` with an actionable message if the setting is
+    missing, which happens when the optional real-time collaboration backend
+    (`jupyter-server-documents`) is not installed.
+    """
+    try:
+        return serverapp.web_app.settings[key]
+    except KeyError as e:
+        raise RuntimeError(_RTC_REQUIRED_MESSAGE) from e
+
+
 def normalize_filepath(file_path: str) -> str:
     """
     Normalizes a file path for Jupyter applications to return an absolute path.
@@ -76,7 +98,7 @@ async def get_jupyter_ydoc(file_id: str):
         `YNotebook` ydoc for the notebook
     """
     serverapp = get_serverapp()
-    yroom_manager = serverapp.web_app.settings["yroom_manager"]
+    yroom_manager = _require_web_app_setting(serverapp, "yroom_manager")
     room_id = f"json:notebook:{file_id}"
 
     if yroom_manager.has_room(room_id):
@@ -87,7 +109,7 @@ async def get_jupyter_ydoc(file_id: str):
 
 async def get_global_awareness() -> Optional[Awareness]:
     serverapp = get_serverapp()
-    yroom_manager = serverapp.web_app.settings["yroom_manager"]
+    yroom_manager = _require_web_app_setting(serverapp, "yroom_manager")
 
     room_id = "JupyterLab:globalAwareness"
     if yroom_manager.has_room(room_id):
@@ -111,7 +133,7 @@ async def get_file_id(file_path: str) -> str:
     normalized_file_path = normalize_filepath(file_path)
 
     serverapp = get_serverapp()
-    file_id_manager = serverapp.web_app.settings["file_id_manager"]
+    file_id_manager = _require_web_app_setting(serverapp, "file_id_manager")
     file_id = file_id_manager.get_id(normalized_file_path)
 
     return file_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,23 +45,16 @@ dependencies = [
     "langchain>=1.0.0",
     # Provides the base checkpointer (`InMemorySaver`) used for in-memory
     # conversation memory. Persistent, SQLite-backed memory is available via the
-    # optional `persistence` extra, and the live notebook tools via the optional
-    # `rtc` extra (see `[project.optional-dependencies]` below).
+    # optional `persistence` extra.
     "langgraph-checkpoint>=2.1.0",
     "langchain_mcp_adapters>=0.2,<0.3",
+    "jupyter_server_documents>=0.1.0a8",
     "jupyterlab-commands-toolkit>=0.1.2",
+    "jupyterlab-notebook-awareness>=0.2.0",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
-# Real-time collaboration support for Jupyternaut's live notebook tools:
-# server-side document rooms plus frontend active-notebook/cell awareness.
-# Without it, chat and the non-notebook tools still work, but the notebook tools
-# are unavailable.
-rtc = [
-    "jupyter_server_documents>=0.1.0a8",
-    "jupyterlab-notebook-awareness>=0.2.0",
-]
 # Persist conversation memory to a local SQLite database so that it survives
 # server restarts. Without it, Jupyternaut keeps conversation memory only for
 # the lifetime of the server process (in-memory).
@@ -71,7 +64,7 @@ persistence = [
 ]
 # All optional runtime features.
 all = [
-    "jupyter_ai_jupyternaut[rtc,persistence]",
+    "jupyter_ai_jupyternaut[persistence]",
 ]
 test = [
     "coverage",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,16 +50,17 @@ dependencies = [
     "langgraph-checkpoint>=2.1.0",
     "langchain_mcp_adapters>=0.2,<0.3",
     "jupyterlab-commands-toolkit>=0.1.2",
-    "jupyterlab-notebook-awareness>=0.2.0",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
-# Real-time collaboration backend (provides the server-side `yroom_manager`)
-# that powers Jupyternaut's live notebook tools. Without it, chat and the
-# non-notebook tools still work, but the notebook tools are unavailable.
+# Real-time collaboration support for Jupyternaut's live notebook tools:
+# server-side document rooms plus frontend active-notebook/cell awareness.
+# Without it, chat and the non-notebook tools still work, but the notebook tools
+# are unavailable.
 rtc = [
     "jupyter_server_documents>=0.1.0a8",
+    "jupyterlab-notebook-awareness>=0.2.0",
 ]
 # Persist conversation memory to a local SQLite database so that it survives
 # server restarts. Without it, Jupyternaut keeps conversation memory only for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,16 +43,35 @@ dependencies = [
     "python_dotenv>=1,<2",
     "jupyter_ai_persona_manager>=0.0.1",
     "langchain>=1.0.0",
-    "langgraph-checkpoint-sqlite>=3.0.0",
+    # Provides the base checkpointer (`InMemorySaver`) used for in-memory
+    # conversation memory. Persistent, SQLite-backed memory is available via the
+    # optional `persistence` extra, and the live notebook tools via the optional
+    # `rtc` extra (see `[project.optional-dependencies]` below).
+    "langgraph-checkpoint>=2.1.0",
     "langchain_mcp_adapters>=0.2,<0.3",
-    "aiosqlite>=0.20",
-    "jupyter_server_documents>=0.1.0a8",
     "jupyterlab-commands-toolkit>=0.1.2",
     "jupyterlab-notebook-awareness>=0.2.0",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]
+# Real-time collaboration backend (provides the server-side `yroom_manager`)
+# that powers Jupyternaut's live notebook tools. Without it, chat and the
+# non-notebook tools still work, but the notebook tools are unavailable.
+rtc = [
+    "jupyter_server_documents>=0.1.0a8",
+]
+# Persist conversation memory to a local SQLite database so that it survives
+# server restarts. Without it, Jupyternaut keeps conversation memory only for
+# the lifetime of the server process (in-memory).
+persistence = [
+    "langgraph-checkpoint-sqlite>=3.0.0",
+    "aiosqlite>=0.20",
+]
+# All optional runtime features.
+all = [
+    "jupyter_ai_jupyternaut[rtc,persistence]",
+]
 test = [
     "coverage",
     "pytest",


### PR DESCRIPTION
Looking into simplifying what dependencies are strictly required for Jupyternaut, and which dependencies can be marked as optional to allow for great compatibility across various deployment use cases.

This will also help packaging `jupyter-ai-jupyternaut` for conda-forge.