### PR TITLE
increase default for num_ctx for ollama models

### DIFF
--- a/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
@@ -273,6 +273,8 @@ class ChatLiteLLM(BaseChatModel):
     """Number of chat completions to generate for each prompt. Note that the API may
        not return the full n completions if duplicates are generated."""
     max_tokens: Optional[int] = None
+    num_ctx: Optional[int] = None
+    """Size of the context window"""
 
     max_retries: int = 1
 
@@ -321,7 +323,10 @@ class ChatLiteLLM(BaseChatModel):
             "force_timeout": self.request_timeout,
             "api_base": self.api_base,
         }
-        return {**self._default_params, **creds}
+        params = {**self._default_params, **creds}
+        if self.num_ctx is not None:
+            params['num_ctx'] = self.num_ctx
+        return params
 
     def completion_with_retry(
         self, run_manager: Optional[CallbackManagerForLLMRun] = None, **kwargs: Any
@@ -416,6 +421,9 @@ class ChatLiteLLM(BaseChatModel):
 
         if values["top_k"] is not None and values["top_k"] <= 0:
             raise ValueError("top_k must be positive")
+
+        if values["num_ctx"] is not None and values["num_ctx"] <= 0:
+            raise ValueError("num_ctx must be positive")
 
         return values
 
@@ -624,7 +632,7 @@ class ChatLiteLLM(BaseChatModel):
             "temperature": self.temperature,
             "top_p": self.top_p,
             "top_k": self.top_k,
-            "n": self.n,
+            "n": self.n
         }
 
     @property

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -19,6 +19,10 @@ from .toolkits.notebook import toolkit as nb_toolkit
 from .toolkits.jupyterlab import toolkit as jlab_toolkit
 from .toolkits.code_execution import toolkit as exec_toolkit
 
+# if the context window is too small it won't see all of the
+# system prompt
+DEFAULT_OLLAMA_NUM_CTX = 16384
+
 MEMORY_STORE_PATH = os.path.join(jupyter_data_dir(), "jupyter_ai", "memory.sqlite")
 
 JUPYTERNAUT_AVATAR_PATH = str(
@@ -83,6 +87,9 @@ class JupyternautPersona(BasePersona):
         return handle_tool_errors
 
     async def get_agent(self, model_id: str, model_args, system_prompt: str):
+        if (model_id.startswith("ollama/") or model_id.startswith("ollama_chat/")) \
+            and "num_ctx" not in model_args:
+                model_args['num_ctx'] = DEFAULT_OLLAMA_NUM_CTX
         model = ChatLiteLLM(**model_args, model=model_id, streaming=True)
         memory_store = await self.get_memory_store()
 


### PR DESCRIPTION
This increases the default for num_ctx for ollama models as the system of default of 2048 is too small for the jupyternaut system prompt.  Fixes #51 

This might be better to allow the user to configure num_ctx through the extension configuration system but will need help with this.