### PR TITLE
Added option to set the context window for Ollama models

### DIFF
--- a/jupyter_ai_jupyternaut/models/parameter_schemas.py
+++ b/jupyter_ai_jupyternaut/models/parameter_schemas.py
@@ -108,6 +108,11 @@ PARAMETER_SCHEMAS: dict[str, dict[str, Any]] = {
     "api_base": {
         "type": "string",
         "description": "Base URL where LLM requests are sent, used for local models, enterprise proxies, or other hosting providers (e.g. vLLM)."
+    },
+    "num_ctx": {
+        "type": "integer",
+        "min": 1,
+        "description": "Context window size (in tokens) for Ollama models. Controls how much context the model can use."
     }
 }
 

--- a/jupyter_ai_jupyternaut/models/parameters_rest_api.py
+++ b/jupyter_ai_jupyternaut/models/parameters_rest_api.py
@@ -54,6 +54,15 @@ class ModelParametersRestAPI(BaseAPIHandler):
                 parameter_names = common_params
             # always include client parameters
             parameter_names.extend(client_params)
+            # Include Ollama-specific params not returned by get_supported_openai_params
+            is_ollama = provider == "ollama" or (
+                model is not None and (
+                    model.startswith("ollama/") or model.startswith("ollama_chat/")
+                )
+            )
+            if is_ollama:
+                ollama_params = ["num_ctx"]
+                parameter_names.extend(p for p in ollama_params if p not in parameter_names)
             # Filter out excluded params
             parameter_names = [n for n in parameter_names if n not in EXCLUDED_PARAMS]
             


### PR DESCRIPTION
Relates to PR #60 

In this PR the context window for Ollama models was extended to size 16384, but the option to vary the context window in "Model parameters" was not added, this PR extends the earlier PR to allow the user to modify the context window. Added an extra parameter selection choice `num_ctx`.

<img width="900" height="829" alt="Screenshot 2026-06-10 at 6 02 42 AM" src="https://github.com/user-attachments/assets/53fe663e-9dd0-4b38-b9d0-8a91256d85a5" />
