### PR TITLE
fix: catch litellm AuthenticationError to prevent silent streaming crashes

### DIFF
--- a/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
@@ -327,16 +327,21 @@ class ChatLiteLLM(BaseChatModel):
         if self.num_ctx is not None:
             params['num_ctx'] = self.num_ctx
         return params
-
+    
+    
     def completion_with_retry(
         self, run_manager: Optional[CallbackManagerForLLMRun] = None, **kwargs: Any
     ) -> Any:
         """Use tenacity to retry the completion call."""
+        import litellm
         retry_decorator = _create_retry_decorator(self, run_manager=run_manager)
 
         @retry_decorator
         def _completion_with_retry(**kwargs: Any) -> Any:
-            return self.client.completion(**kwargs)
+            try:
+                return self.client.completion(**kwargs)
+            except litellm.exceptions.AuthenticationError as e:
+                raise ChatLiteLLMException(f"Authentication Failed: {str(e)}") from e
 
         return _completion_with_retry(**kwargs)
 
@@ -347,6 +352,7 @@ class ChatLiteLLM(BaseChatModel):
         **kwargs: Any
     ) -> Any:
         """Use tenacity to retry the async completion call."""
+        import litellm
         retry_decorator = _create_retry_decorator(self, run_manager=run_manager)
 
         # Enables ephemeral prompt caching of the last system message by
@@ -369,13 +375,15 @@ class ChatLiteLLM(BaseChatModel):
 
         @retry_decorator
         async def _completion_with_retry(**kwargs: Any) -> Any:
-            return await self.client.acompletion(
-                **kwargs,
-                **cache_control_kwargs,
-            )
+            try:
+                return await self.client.acompletion(
+                    **kwargs,
+                    **cache_control_kwargs,
+                )
+            except litellm.exceptions.AuthenticationError as e:
+                raise ChatLiteLLMException(f"Authentication Failed: {str(e)}") from e
 
         return await _completion_with_retry(**kwargs)
-
     @pre_init
     def validate_environment(cls, values: Dict) -> Dict:
         """Validate api key, python package exists, temperature, top_p, and top_k."""


### PR DESCRIPTION
### Description

When an API key (such as `ANTHROPIC_API_KEY`) is completely missing or omitted from the environment variables during a streaming chat interaction, `litellm` raises an unhandled `litellm.exceptions.AuthenticationError`. Because this exception is not caught within the core model completion wrappers, it bubbles up raw, completely disrupting the `PersonaManagerExtension` execution pipeline and throwing a massive stack trace in the logs.

This PR addresses the issue by explicitly catching `litellm.exceptions.AuthenticationError` inside both the synchronous `completion_with_retry` and asynchronous `acompletion_with_retry` execution methods in `chat_models.py`. The error is caught and re-raised as a clean `ChatLiteLLMException`.

### Changes

* Wrapped core `self.client.completion` and `self.client.acompletion` calls in `try/except` blocks.
* Intercepted `litellm.exceptions.AuthenticationError`.
* Re-raised the authentication error cleanly as a `ChatLiteLLMException`, enabling the upstream interface to gracefully present the validation failure to the user rather than crashing the streaming thread.

### Related Issues

Fixes an issue where missing API keys cause silent stream execution loop crashes.