### PR TITLE
Allow jupyternaut to connect to openclaw and hermes

### DIFF
--- a/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/chat_models.py
@@ -72,6 +72,41 @@ class ChatLiteLLMException(Exception):
     """Error with the `LiteLLM I/O` library"""
 
 
+def _remove_reasoning_objects(obj):
+    """
+    Recursively remove any dictionary objects where type is set to "reasoning".
+
+    Args:
+        obj: The object to process (dict, list, or other value)
+
+    Returns:
+        The cleaned object with reasoning dicts removed
+    """
+    if isinstance(obj, dict):
+        # Check if this dict has type="reasoning" - remove it entirely
+        if obj.get('type') == 'reasoning':
+            return None
+
+        # Otherwise, recursively process each key-value pair
+        result = {}
+        for key, value in obj.items():
+            processed = _remove_reasoning_objects(value)
+            if processed is not None:
+                result[key] = processed
+        return result
+
+    elif isinstance(obj, list):
+        # Recursively process list items, filtering out None values
+        result = []
+        for item in obj:
+            processed = _remove_reasoning_objects(item)
+            if processed is not None:
+                result.append(processed)
+        return result
+    else:
+        # Return primitive values unchanged
+        return obj
+
 def _create_retry_decorator(
     llm: ChatLiteLLM,
     run_manager: Optional[
@@ -200,7 +235,6 @@ def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
             "arguments": json.dumps(tool_call["args"]),
         },
     }
-
 
 def _convert_message_to_dict(message: BaseMessage) -> dict:
     message_dict: Dict[str, Any] = {"content": message.content}
@@ -427,6 +461,9 @@ class ChatLiteLLM(BaseChatModel):
 
         return values
 
+
+
+
     def _generate(
         self,
         messages: List[BaseMessage],
@@ -443,6 +480,8 @@ class ChatLiteLLM(BaseChatModel):
             return generate_from_stream(stream_iter)
 
         message_dicts, params = self._create_message_dicts(messages, stop)
+        message_dicts = _remove_reasoning_objects(message_dicts)
+
         params = {**params, **kwargs}
         response = self.completion_with_retry(
             messages=message_dicts, run_manager=run_manager, **params

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -152,7 +152,7 @@ class JupyternautPersona(BasePersona):
             model_args['num_ctx'] = DEFAULT_OLLAMA_NUM_CTX
         model = ChatLiteLLM(**model_args, model=model_id, streaming=True)
         memory_store = (await self.get_memory_store()) \
-            if is_true_flexible(model_args.get('memory_store', "true")) \
+            if is_true_flexible(model_args.get('persistence', "true")) \
             else InMemorySaver()
 
         return create_agent(

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -18,7 +18,6 @@ from langchain_mcp_adapters.sessions import (
   StreamableHttpConnection,
   StdioConnection,
 )
-from langgraph.checkpoint.memory import InMemorySaver
 
 from .chat_models import ChatLiteLLM
 from .prompt_template import (
@@ -78,7 +77,7 @@ class JupyternautPersona(BasePersona):
             import aiosqlite
             from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
         except ImportError:
-            pass
+            from langgraph.checkpoint.memory import InMemorySaver
 
             self.log.info(
                 "`langgraph-checkpoint-sqlite` is not installed; Jupyternaut "
@@ -149,8 +148,10 @@ class JupyternautPersona(BasePersona):
 
         if (model_id.startswith("ollama/") or model_id.startswith("ollama_chat/")) \
             and "num_ctx" not in model_args:
-            model_args['num_ctx'] = DEFAULT_OLLAMA_NUM_CTX
+                model_args['num_ctx'] = DEFAULT_OLLAMA_NUM_CTX
         model = ChatLiteLLM(**model_args, model=model_id, streaming=True)
+
+        from langgraph.checkpoint.memory import InMemorySaver
         memory_store = (await self.get_memory_store()) \
             if is_true_flexible(model_args.get('persistence', "true")) \
             else InMemorySaver()

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -18,6 +18,7 @@ from langchain_mcp_adapters.sessions import (
   StreamableHttpConnection,
   StdioConnection,
 )
+from langgraph.checkpoint.memory import InMemorySaver
 
 from .chat_models import ChatLiteLLM
 from .prompt_template import (
@@ -77,7 +78,7 @@ class JupyternautPersona(BasePersona):
             import aiosqlite
             from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
         except ImportError:
-            from langgraph.checkpoint.memory import InMemorySaver
+            pass
 
             self.log.info(
                 "`langgraph-checkpoint-sqlite` is not installed; Jupyternaut "
@@ -143,11 +144,16 @@ class JupyternautPersona(BasePersona):
         return handle_tool_errors
 
     async def get_agent(self, model_id: str, model_args, system_prompt: str):
+        def is_true_flexible(val: str) -> bool:
+            return val.strip().lower() in ("true", "1", "yes", "y", "t")
+
         if (model_id.startswith("ollama/") or model_id.startswith("ollama_chat/")) \
             and "num_ctx" not in model_args:
-                model_args['num_ctx'] = DEFAULT_OLLAMA_NUM_CTX
+            model_args['num_ctx'] = DEFAULT_OLLAMA_NUM_CTX
         model = ChatLiteLLM(**model_args, model=model_id, streaming=True)
-        memory_store = await self.get_memory_store()
+        memory_store = (await self.get_memory_store()) \
+            if is_true_flexible(model_args.get('memory_store', "true")) \
+            else InMemorySaver()
 
         return create_agent(
             model,
@@ -172,13 +178,23 @@ class JupyternautPersona(BasePersona):
             return
 
         try:
-            model_id = self.config_manager.chat_model
-            model_args = self.config_manager.chat_model_args
-            system_prompt = self.get_system_prompt(model_id=model_id, message=message)
-            agent = await self.get_agent(
-                model_id=model_id, model_args=model_args, system_prompt=system_prompt
+            model_id = (message.metadata or {}).get(
+                "model_id", self.config_manager.chat_model
             )
-
+            model_args = self.config_manager.chat_model_args | \
+                (message.metadata or {}).get(
+                    "model_args", {}
+                )
+            system_prompt = self.get_system_prompt(
+                model_id=model_id,
+                message=message
+            )
+            self.log.debug("%s %s", model_id, model_args)
+            agent = await self.get_agent(
+                model_id=model_id,
+                model_args=model_args,
+                system_prompt=system_prompt
+            )
             context = {
                 "thread_id": self.ychat.get_id(),
                 "username": message.sender

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -92,12 +92,9 @@ class JupyternautPersona(BasePersona):
         return AsyncSqliteSaver(conn)
 
     async def get_tools(self, skip_exec_toolkit: bool=False):
-        tools = nb_toolkit
-        tools += jlab_toolkit
-
         # Bash tool conflicts with internal openclaw tools
-        if not skip_exec_toolkit:
-            tools += exec_toolkit
+        tools = nb_toolkit + jlab_toolkit + \
+            (exec_toolkit if not skip_exec_toolkit else [])
 
         # Add MCP tools
         mcp_settings = self.get_mcp_settings()

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -178,17 +178,19 @@ class JupyternautPersona(BasePersona):
                 "Please make sure to first install that package in your environment & restart the server.",
             )
             return
-        if not self.config_manager.chat_model:
+
+        model_id = (message.metadata or {}).get(
+            "model_id", self.config_manager.chat_model
+        )
+
+        if not model_id:
             self.send_message(
                 "No chat model is configured.\n\n"
-                "You must set one first in the Jupyter AI settings, found in 'Settings > AI Settings' from the menu bar."
+                "You must set one first in the Jupyter AI settings, found in 'Settings > Jupyternaut settings' from the menu bar."
             )
             return
 
         try:
-            model_id = (message.metadata or {}).get(
-                "model_id", self.config_manager.chat_model
-            )
             model_args = self.config_manager.chat_model_args | \
                 (message.metadata or {}).get(
                     "model_args", {}

--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -91,10 +91,13 @@ class JupyternautPersona(BasePersona):
         conn = await aiosqlite.connect(MEMORY_STORE_PATH, check_same_thread=False)
         return AsyncSqliteSaver(conn)
 
-    async def get_tools(self):
+    async def get_tools(self, skip_exec_toolkit: bool=False):
         tools = nb_toolkit
         tools += jlab_toolkit
-        tools += exec_toolkit
+
+        # Bash tool conflicts with internal openclaw tools
+        if not skip_exec_toolkit:
+            tools += exec_toolkit
 
         # Add MCP tools
         mcp_settings = self.get_mcp_settings()
@@ -152,16 +155,23 @@ class JupyternautPersona(BasePersona):
         model = ChatLiteLLM(**model_args, model=model_id, streaming=True)
 
         from langgraph.checkpoint.memory import InMemorySaver
-        memory_store = (await self.get_memory_store()) \
-            if is_true_flexible(model_args.get('persistence', "true")) \
-            else InMemorySaver()
+        use_persistence = is_true_flexible(model_args.get(
+            'persistence', "false" if "/openclaw" in model_id or "/hermes" in model_id else "true"
+        ))
+
+        # openclaw will fail if you pass it a bash tool as this conflicts with the
+        # internal openclaw tool.  It will also fail if persistence is true and it
+        # pulls in a bash tool from a previous run
+
+        skip_exec_toolkit = "/openclaw" in model_id
+        memory_store = (await self.get_memory_store()) if use_persistence else InMemorySaver()
 
         return create_agent(
             model,
             system_prompt=system_prompt,
             checkpointer=memory_store,
-            tools=await self.get_tools(),
-            middleware=[self._create_tool_error_handler()],
+            tools=await self.get_tools(skip_exec_toolkit),
+            middleware=[self._create_tool_error_handler()]
         )
 
     async def process_message(self, message: Message) -> None:


### PR DESCRIPTION
This are fixes to allow jupyternaut to connect to hermes and openclaw.  This disables the tool bash when connecting with openclaw and removes reasoning from the request send to openai.

```
%%ai @Jupyternaut -m '{"model_id": "openai/openclaw", "model_args": {"api_base": "http://openclaw:18789/v1", "persistence": "true"}}'

%%ai @Jupyternaut -m '{"model_id": "openai/hermes", "model_args": {"api_base": "http://hermes:8642/v1"}}'
```