### PR TITLE
Group Dependabot npm updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-version-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Motivation

Dependabot currently opens one PR per dependency update. Right now this repo has 9 open Dependabot PRs (all npm security updates), which is a lot of individual reviews and CI runs for routine dependency bumps.

## Summary

Adds a `.github/dependabot.yml` that groups all npm updates into a single PR per run. There are two groups both matching `*`: one for `version-updates` and one for `security-updates`. Grouping applies per update type — Dependabot never mixes version and security updates in the same PR — so both groups are needed to cover routine bumps and security bumps.

Once this merges, the existing ungrouped PRs are closed and Dependabot re-opens a single grouped PR.