### PR TITLE
Make Dependabot config security-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,20 @@
+# Security-only Dependabot config: no routine version-update PRs, only
+# grouped security updates.
+#
+# `open-pull-requests-limit: 0` disables version-update PRs entirely — this is
+# the documented way to keep security updates while turning off routine bumps.
+# Security updates are driven by Dependabot alerts and run regardless of this
+# limit or the schedule below. See "Overriding the default behavior with a
+# configuration file":
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-security-updates#overriding-the-default-behavior-with-a-configuration-file
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
-      npm-version-updates:
-        applies-to: version-updates
-        patterns:
-          - "*"
       npm-security-updates:
         applies-to: security-updates
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    # `schedule.interval` is a required key, but it only governs version
+    # updates — which are disabled below — so its value is inert here.
+    # Security updates are triggered by Dependabot alerts, not this schedule.
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 0


### PR DESCRIPTION
## Motivation

The dependabot config added in #81 grouped *all* npm updates — but it also enabled routine version-update PRs (bumping every dependency to the latest in-range version on a weekly schedule). That's more churn than wanted: the goal is to only update dependencies in response to security advisories, not to chase every new release.

## Summary

Switches the config to security-only. `open-pull-requests-limit: 0` disables version-update PRs entirely, while grouped security updates keep working — they're driven by Dependabot alerts and run regardless of that limit or the schedule. The single `npm-security-updates` group collapses all npm security bumps into one PR.

Net effect: no more routine version bumps; a grouped PR appears only when a security advisory affects an npm dependency.