### PR TITLE
Gate lockfile workflow on PR author, not github.actor

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -55,8 +55,11 @@ permissions:
 
 jobs:
   update-lockfile:
-    # Only run on Dependabot's own PRs.
-    if: github.actor == 'dependabot[bot]'
+    # Only run on Dependabot's own PRs. Gate on the PR AUTHOR, not github.actor:
+    # github.actor is whoever last triggered the run, so a human re-running CI on
+    # a Dependabot PR would make it skip. The PR author is stable regardless of
+    # who kicks the run.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Generate a GitHub App token


### PR DESCRIPTION
## Motivation

The lockfile workflow gated on `github.actor == 'dependabot[bot]'`. But `github.actor` is whoever *last triggered the run*, not the PR author — so when a human re-runs CI on a Dependabot PR (as happened on #87), the job skips exactly when it's needed. #87 is the grouped security PR: its `build` failed on the out-of-sync `yarn.lock`, and `update-lockfile` skipped because I'd re-kicked CI, making me the actor.

## Summary

Gates on `github.event.pull_request.user.login == 'dependabot[bot]'` instead — the PR author, which is stable no matter who triggers the run. This is the field GitHub's own Dependabot-automation docs use.