### PR TITLE
add tools to empty list

### DIFF
--- a/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/jupyternaut.py
@@ -280,7 +280,8 @@ class JupyternautPersona(BasePersona):
         return AsyncSqliteSaver(conn)
 
     async def get_tools(self):
-        tools = nb_toolkit
+        tools = []
+        tools += nb_toolkit
         tools += jlab_toolkit
         tools += exec_toolkit
 


### PR DESCRIPTION
python is pass by reference which means that the existing code adds the tooling to the original list. which is not what you want