### PR TITLE
Resolve App ID from vars or secrets in lockfile workflow

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -15,16 +15,17 @@
 # This reuses the same GitHub App as the release workflow (publish-release.yml),
 # which reads `vars.APP_ID` / `secrets.APP_PRIVATE_KEY`. No new App is needed.
 #
-# Setup required (one time, by a repo admin): Dependabot-triggered runs do NOT
-# see Actions secrets/variables — they only see *Dependabot* secrets. So the
-# App's credentials must ALSO be added under Settings -> Secrets and variables
-# -> Dependabot (note: Dependabot has secrets only, no variables, so APP_ID goes
-# there as a secret too):
-#   - APP_ID
-#   - APP_PRIVATE_KEY
-# Until those Dependabot secrets exist, the token step fails and the run goes
-# red on Dependabot PRs — an honest signal that setup is incomplete. This
-# workflow only runs on Dependabot PRs, so it never affects human PRs.
+# Secret source depends on WHO triggers the run. Only a Dependabot-triggered
+# run sees the *Dependabot* secret store; any re-trigger by a human or another
+# bot (e.g. the release App rebasing the branch) uses the *Actions* store. The
+# credentials must therefore exist in BOTH stores:
+#   - Actions:    vars.APP_ID (variable) + secrets.APP_PRIVATE_KEY  (already set
+#                 for publish-release.yml)
+#   - Dependabot: secrets.APP_ID + secrets.APP_PRIVATE_KEY  (add under
+#                 Settings -> Secrets and variables -> Dependabot; note
+#                 Dependabot has no variables, so APP_ID goes there as a secret)
+# The token step below reads `vars.APP_ID || secrets.APP_ID` so it resolves
+# under either source.
 #
 # Security posture (why the App credential is not meaningfully exposed here):
 #   - The App token is EPHEMERAL — create-github-app-token mints an installation
@@ -73,7 +74,13 @@ jobs:
         # "not configured yet" signal rather than a silent skip.
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          # Resolve from BOTH secret stores. A run only sees the *Dependabot*
+          # secret store when Dependabot itself triggers it; any re-trigger by a
+          # human or another bot (e.g. the release App rebasing the branch) uses
+          # the *Actions* store instead. On the Actions side APP_ID is a variable
+          # (vars.APP_ID, per publish-release.yml); on the Dependabot side it's a
+          # secret. This fallback works regardless of which store is active.
+          app-id: ${{ vars.APP_ID || secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # Scope the token to this repo only, not the whole installation.
           owner: ${{ github.repository_owner }}


### PR DESCRIPTION
## Motivation

The lockfile workflow still failed on #87 with "Input required and not supplied: app-id", even after the Dependabot `APP_ID` secret was added. The run log showed `Secret source: Actions` — because the run was re-triggered by the release App (rebasing the branch), not by Dependabot.

A run only sees the *Dependabot* secret store when Dependabot itself triggers it. Any re-trigger by a human or another bot uses the *Actions* store, where `APP_ID` is a variable (`vars.APP_ID`), not a secret — so `secrets.APP_ID` resolved empty.

## Summary

Reads `app-id: ${{ vars.APP_ID || secrets.APP_ID }}` so it resolves under either source: `vars.APP_ID` for Actions-sourced runs, falling back to `secrets.APP_ID` for Dependabot-sourced runs. `APP_PRIVATE_KEY` already exists as a secret in both stores. No new secrets needed.