### PR TITLE
fix internal api breakage in mcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,10 @@ dependencies = [
     # conversation memory. Persistent, SQLite-backed memory is available via the
     # optional `persistence` extra.
     "langgraph-checkpoint>=2.1.0",
-    "langchain_mcp_adapters>=0.2,<0.3",
+    "langchain_mcp_adapters>=0.3",
+    # require early version of mcp to allow load of
+    # langchain_mcp_adapters. see issue #89
+    "mcp<2",
     "jupyter_server_documents>=0.1.0a8",
     "jupyterlab-commands-toolkit>=0.1.2",
     "jupyterlab-notebook-awareness>=0.2.0",


### PR DESCRIPTION
This fixes the crash in #89 .  The mcp API is changing in 2.0