### PR TITLE
rename tools

### DIFF
--- a/jupyter_ai_jupyternaut/jupyternaut/toolkits/code_execution.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/toolkits/code_execution.py
@@ -3,8 +3,9 @@
 import asyncio
 import shlex
 from typing import Optional
+from langchain.tools import tool
 
-
+@tool("jpnaut/bash")
 async def bash(command: str, timeout: Optional[int] = None) -> str:
     """Executes a bash command and returns the result
 

--- a/jupyter_ai_jupyternaut/jupyternaut/toolkits/jupyterlab.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/toolkits/jupyterlab.py
@@ -3,8 +3,9 @@ from typing import Optional
 from jupyterlab_commands_toolkit.tools import execute_command
 
 from .utils import get_serverapp
+from langchain.tools import tool
 
-
+@tool("jpnaut/open_file")
 async def open_file(file_path: str):
     """
     Opens a file in JupyterLab main area
@@ -43,13 +44,14 @@ async def open_file(file_path: str):
     return await execute_command("docmanager:open", {"path": file_path})
 
 
+@tool("jpnaut/run_all_cells")
 async def run_all_cells():
     """
     Runs all cells in the currently active Jupyter notebook
     """
     return await execute_command("notebook:run-all-cells")
 
-
+@tool("jpnaut/run_cell")
 async def run_cell(cell_id: str, username: Optional[str] = None) -> dict:
     """
     Runs a specific cell in the active notebook by selecting it and executing it.
@@ -73,13 +75,11 @@ async def run_cell(cell_id: str, username: Optional[str] = None) -> dict:
     # Then run the currently selected cell
     return await execute_command("notebook:run-cell")
 
-
 async def select_cell_below():
     """
     Moves the cursor down to select the cell below the currently selected cell
     """
     return await execute_command("notebook:move-cursor-down")
-
 
 async def select_cell_above():
     """
@@ -87,7 +87,7 @@ async def select_cell_above():
     """
     return await execute_command("notebook:move-cursor-up")
 
-
+@tool("jpnaut/restart_kernel")
 async def restart_kernel():
     """
     Restarts the notebook kernel, useful when new packages are installed

--- a/jupyter_ai_jupyternaut/jupyternaut/toolkits/notebook.py
+++ b/jupyter_ai_jupyternaut/jupyternaut/toolkits/notebook.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 from typing import Any, Dict, List, Literal, Optional, Union
+from langchain.tools import tool
 
 import nbformat
 from jupyter_ydoc import YNotebook
@@ -197,6 +198,7 @@ def format_notebook_cell(
     return formatted_cell
 
 
+@tool("jpnaut/read_notebook_cells")
 async def read_notebook_cells(
     notebook_path: str, specific_cell_id: Optional[str] = None
 ) -> List[Dict[str, Any]]:
@@ -307,7 +309,7 @@ async def get_cell_id_from_index(file_path: str, cell_index: int) -> str:
     except Exception:
         raise
 
-
+@tool("jpnaut/add_cell")
 async def add_cell(
     file_path: str,
     content: str | None = None,
@@ -399,7 +401,7 @@ async def add_cell(
     except Exception:
         raise
 
-
+@tool("jpnaut/delete_cell")
 async def delete_cell(file_path: str, cell_id: str):
     """Removes a notebook cell with the specified cell ID.
 
@@ -545,7 +547,7 @@ def set_cursor_in_ynotebook(
         # This is intentional - cursor positioning is a visual enhancement, not critical
         pass
 
-
+@tool("jpnaut/write_to_cell_collaboratively")
 async def write_to_cell_collaboratively(
     ynotebook, ycell, content: str, typing_speed: float = 0.1
 ) -> bool:
@@ -864,6 +866,7 @@ def _safe_set_cursor(
         # Cursor positioning is a visual enhancement, not critical functionality
         pass
 
+@tool("jpnaut/get_open_documents")
 async def get_open_documents(username: Optional[str] = None) -> Optional[List[str]]:
     """
     Returns all open documents for the user, excluding chat files.
@@ -893,6 +896,7 @@ async def get_open_documents(username: Optional[str] = None) -> Optional[List[st
     return None
 
 
+@tool("jpnaut/get_active_notebook")
 async def get_active_notebook(username: Optional[str] = None) -> Optional[str]:
     """
     Returns path for the currently active notebook.
@@ -920,7 +924,7 @@ async def get_active_notebook(username: Optional[str] = None) -> Optional[str]:
             # if only one notebook is open, return it
             if len(notebooks) == 1:
                 return notebooks[0]
-        
+
 def _get_active_cell_id_from_ydoc(ydoc: YNotebook, username: Optional[str] = None) -> Optional[str]:
     """Internal helper: Returns the active cell id from a ydoc instance
 
@@ -946,6 +950,7 @@ def _get_active_cell_id_from_ydoc(ydoc: YNotebook, username: Optional[str] = Non
     return None
 
 
+@tool("jpnaut/get_active_cell_id")
 async def get_active_cell_id(notebook_path: str, username: Optional[str] = None) -> Optional[str]:
     """Returns the active cell id
 
@@ -963,6 +968,7 @@ async def get_active_cell_id(notebook_path: str, username: Optional[str] = None)
     return _get_active_cell_id_from_ydoc(ydoc, username)
 
 
+@tool("jpnaut/select_cell")
 async def select_cell(cell_id: str, username: Optional[str] = None) -> dict:
     """
     Selects a cell in the active notebook by navigating to it using cursor movements.


### PR DESCRIPTION
This renames the tools to include a jpnaut/ in  order a prevent namespace collisions.  This is a particular issue with the tool 
"bash" which interferes with tools and skills in other agents.