### PR TITLE
fix: prevent raw HTML error dumps in settings UI  

### DIFF
--- a/src/components/settings/secrets-section.tsx
+++ b/src/components/settings/secrets-section.tsx
@@ -26,18 +26,22 @@ export function SecretsSection(): JSX.Element {
    * `loading` state accordingly.
    */
   const loadSecrets = async () => {
-    try {
-      setLoading(true);
-      const secrets = await AiService.listSecrets();
-      setEditableSecrets(secrets.editable_secrets);
-      setStaticSecrets(secrets.static_secrets);
-      setError(false);
-    } catch (error) {
-      setError(true);
-      errorAlert.show('error', error as unknown as any);
-    } finally {
-      setLoading(false);
-    }
+      try {
+        setLoading(true);
+        const secrets = await AiService.listSecrets();
+        setEditableSecrets(secrets.editable_secrets);
+        setStaticSecrets(secrets.static_secrets);
+        setError(false);
+      } catch (error: any) {
+        setError(true);
+        let errorMessage = error?.message || String(error);
+        if (typeof errorMessage === 'string' && errorMessage.trim().startsWith('<')) {
+          errorMessage = 'Failed to fetch secrets from the Jupyter Server. The backend extension may be unreachable or improperly installed.';
+        }
+        errorAlert.show('error', errorMessage);
+      } finally {
+        setLoading(false);
+      }
   };
 
   /**
@@ -45,15 +49,19 @@ export function SecretsSection(): JSX.Element {
    * state. This prevents the child components from being remounted.
    */
   const reloadSecrets = async () => {
-    try {
-      const secrets = await AiService.listSecrets();
-      setEditableSecrets(secrets.editable_secrets);
-      setStaticSecrets(secrets.static_secrets);
-      setError(false);
-    } catch (error) {
-      setError(true);
-      errorAlert.show('error', error as unknown as any);
-    }
+      try {
+        const secrets = await AiService.listSecrets();
+        setEditableSecrets(secrets.editable_secrets);
+        setStaticSecrets(secrets.static_secrets);
+        setError(false);
+      } catch (error: any) {
+        setError(true);
+        let errorMessage = error?.message || String(error);
+        if (typeof errorMessage === 'string' && errorMessage.trim().startsWith('<')) {
+          errorMessage = 'Failed to fetch secrets from the Jupyter Server. The backend extension may be unreachable or improperly installed.';
+        }
+        errorAlert.show('error', errorMessage);
+      }
   };
 
   /**


### PR DESCRIPTION
Fixes #98

Problem:
If a user's backend environment is broken (resulting in a 404 or 500 HTML response from the Jupyter Server), the SecretsSection UI currently catches the raw HTML string and renders it directly into the errorAlert, causing a massive, unreadable red error box.

Solution:
This PR intercepts the error in loadSecrets and reloadSecrets. If the error message is an HTML string, it replaces it with a clean, user-friendly fallback message notifying them that the backend extension may be unreachable or improperly installed.