### PR TITLE
Update langchain-mcp-adapter version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # conversation memory. Persistent, SQLite-backed memory is available via the
     # optional `persistence` extra.
     "langgraph-checkpoint>=2.1.0",
-    "langchain_mcp_adapters>=0.2,<0.3",
+    "langchain_mcp_adapters>=0.3.2,<0.4",
     "jupyter_server_documents>=0.1.0a8",
     "jupyterlab-commands-toolkit>=0.1.2",
     "jupyterlab-notebook-awareness>=0.2.0",


### PR DESCRIPTION
Widens the pin to allow 0.3.2+: change pyproject.toml:51 to something like  langchain_mcp_adapters>=0.3.2,<0.4". This pulls in the version that already caps mcp<2, fixing the resolution cleanly. 

Checked every specific thing jupyternaut touches:

1. Imports — MultiServerMCPClient (from .client), and Connection, StreamableHttpConnection, StdioConnection (from .sessions) all still exist in 0.3.2 with identical names. Verified by actually importing them in a clean venv with 0.3.2 installed — no errors.
2. MultiServerMCPClient(connections) constructor (jupyternaut.py:307) — jupyternaut calls it positionally with just the connections dict, no keyword args. The 0.3.2 constructor added one new optional kwarg, handle_tool_errors: bool = True — purely additive, doesn't affect the  existing call. I constructed it live and confirmed handle_tool_errors defaults to True.
3. client.get_tools() (jupyternaut.py:308) — signature unchanged (server_name optional kwarg, not used by jupyternaut).
4. StreamableHttpConnection / StdioConnection fields — jupyternaut only ever sets transport, url, headers (HTTP) and transport, command, args, env (stdio) — jupyternaut.py:293-304. All of these fields are unchanged between 0.2.2 and 0.3.2. The only field-level change I found was timeout/sse_read_timeout widening from timedelta to float | timedelta — a superset, and jupyternaut doesn't set either field anyway.
5. Tool-error handling — this was the one thing worth being careful about, since 0.3.2 added an internal handle_tool_errors default behavior (auto-converts isError=True MCP results into a ToolMessage instead of raising ToolException). But jupyternaut has its own error-handling middleware (_create_tool_error_handler at jupyternaut.py:312-332, wired in via middleware=[...] at jupyternaut.py:346) that catches any exception at the LangChain agent level and converts it to a ToolMessage itself. So even if the new default suppresses some MCP-level ToolExceptions before they'd reach jupyternaut's handler, the net effect is the same or better — errors still end up as a ToolMessage the model can see, just resolved one layer earlier. No behavior regression, and if anything it's more robust (transport-level failures still raise and hit jupyternaut's handler as before).

No breaking changes hit any code path jupyternaut actually exercises.